### PR TITLE
chore: use .git repository url for testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "💬 a CLI for learning to distribute CLIs in rust"
 version = "0.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/axodotdev/axolotlsay"
+repository = "https://github.com/axodotdev/axolotlsay.git"
 homepage = "https://github.com/axodotdev/axolotlsay"
 authors = ["axodotdev <hello@axo.dev>"]
 


### PR DESCRIPTION
This will be useful as an example for cargo-dist's tests.